### PR TITLE
Add options for strict parsing and pretty printing

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,21 +2,36 @@ package main
 
 import (
 	"os"
+	"flag"
+	"fmt"
 
 	"github.com/bronze1man/yaml2json/y2jLib"
 )
 
-	func main() {
-	if len(os.Args)>1 && os.Args[1]=="--help"{
-		os.Stdout.WriteString(`Transform yaml string to json string without the type infomation.
-Usage:
-echo "a: 1" | yaml2json
-yaml2json < 1.yml > 2.json
-`)
-		os.Exit(1)
-		return
+func main() {
+
+	flag.Usage = func() {
+		out := flag.CommandLine.Output()
+		fmt.Fprintf(out, "%s: Transform yaml string to json string without the type infomation.\n", os.Args[0])
+		fmt.Fprintln(out, "\nOptions:")
+		flag.PrintDefaults()
+		fmt.Fprintln(out,`
+Examples:
+	echo "a: 1" | yaml2json
+	yaml2json < 1.yml > 2.json`)
 	}
-	err := y2jLib.TranslateStream(os.Stdin, os.Stdout)
+
+	parseStrict := flag.Bool("strict", false, "Enable strict YAML parsing.")
+	indent := flag.String("indent", "", "If provided, pretty-prints JSON using the argument as the indent string.")
+
+	flag.Parse()
+
+	options := y2jLib.Options {
+		ParseStrict: *parseStrict,
+		Indent: *indent,
+	}
+
+	err := y2jLib.TranslateStreamWithOptions(os.Stdin, os.Stdout, options)
 	if err == nil{
 		os.Exit(0)
 	}

--- a/y2jLib/lib.go
+++ b/y2jLib/lib.go
@@ -9,8 +9,19 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+type Options struct {
+	ParseStrict bool
+	Indent string
+}
+
 func TranslateStream(in io.Reader, out io.Writer) error {
+	return TranslateStreamWithOptions(in, out, Options{})
+}
+
+func TranslateStreamWithOptions(in io.Reader, out io.Writer, options Options) error {
 	decoder := yaml.NewDecoder(in)
+	decoder.SetStrict(options.ParseStrict)
+
 	for {
 		var data interface{}
 		err := decoder.Decode(&data)
@@ -24,7 +35,7 @@ func TranslateStream(in io.Reader, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		output, err := json.Marshal(data)
+		output, err := marshalToJson(data, options.Indent)
 		if err != nil {
 			return err
 		}
@@ -37,6 +48,14 @@ func TranslateStream(in io.Reader, out io.Writer) error {
 		if err != nil {
 			return err
 		}
+	}
+}
+
+func marshalToJson(v interface{}, indent string) ([]byte, error) {
+	if len(indent) > 0 {
+		return json.MarshalIndent(v, "", indent)
+	} else {
+		return json.Marshal(v)
 	}
 }
 


### PR DESCRIPTION
Two command line options are added:

- `--strict` To enforce strict YAML parsing (https://godoc.org/gopkg.in/yaml.v2#UnmarshalStrict)
- `--indent <arg>` To enable pretty-printing using `<arg>` as the indent string (https://golang.org/pkg/encoding/json/#MarshalIndent)

This is implemented using the standard Go library `flag`: https://golang.org/pkg/flag/

For this purpose, y2jLib is extended with a struct `Options`.  A new function `TranslateStreamWithOptions` is the same as the old `TranslateStream` except with an additional `Options` argument. `TranslateStream` is now just a wrapper for `TranslateStreamWithOptions` with default options.

Additional tests are added.