### PR TITLE
y2jBuilder: code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-yaml2json
+/yaml2json
+/y2jBuilder/y2jBuilder
 
 # goland files
 .idea/

--- a/y2jBuilder/main.go
+++ b/y2jBuilder/main.go
@@ -5,41 +5,42 @@ import (
 	"path/filepath"
 )
 
-func main(){
-	pwd,err:=os.Getwd()
-	if err!=nil{
+func main() {
+	pwd, err := os.Getwd()
+	if err != nil {
 		panic(err)
 	}
-	mustDeleteFile(filepath.Join(pwd,"tmp","file"))
-	mustDeleteFile(filepath.Join(pwd,"tmp","fileZip"))
-	mustRunCmd([]string{"go","test","-v","github.com/bronze1man/yaml2json/y2jLib"},nil)
-	for _,info:=range buildInfoList {
-		outputPath := filepath.Join(pwd,"bin",info.goos+"_"+info.goarch,"yaml2json")
-		if info.goos=="windows"{
-			outputPath+=".exe"
+	mustDeleteFile(filepath.Join(pwd, "tmp", "file"))
+	mustDeleteFile(filepath.Join(pwd, "tmp", "fileZip"))
+	mustRunCmd([]string{"go", "test", "-v", "github.com/bronze1man/yaml2json/y2jLib"}, nil)
+	for _, info := range buildInfoList {
+		outputPath := filepath.Join(pwd, "bin", info.goos+"_"+info.goarch, "yaml2json")
+		if info.goos == "windows" {
+			outputPath += ".exe"
 		}
-		mustRunCmd([]string{"go","build","-o",outputPath,"-ldflags","-s -w","-gcflags=-trimpath","github.com/bronze1man/yaml2json"},map[string]string{
-			"GOOS":info.goos,
-			"GOARCH":info.goarch,
+		mustRunCmd([]string{"go", "build", "-o", outputPath, "-ldflags", "-s -w", "-gcflags=-trimpath", "github.com/bronze1man/yaml2json"}, map[string]string{
+			"GOOS":   info.goos,
+			"GOARCH": info.goarch,
 		})
-		filePath:="yaml2json_"+info.goos+"_"+info.goarch
-		if info.goos=="windows"{
-			filePath+=".exe"
+		filePath := "yaml2json_" + info.goos + "_" + info.goarch
+		if info.goos == "windows" {
+			filePath += ".exe"
 		}
-		mustCopyFile(outputPath,filepath.Join(pwd,"tmp","file",filePath))
-		filePath2:="yaml2json"
-		if info.goos=="windows"{
-			filePath2+=".exe"
+		mustCopyFile(outputPath, filepath.Join(pwd, "tmp", "file", filePath))
+		filePath2 := "yaml2json"
+		if info.goos == "windows" {
+			filePath2 += ".exe"
 		}
-		mustCopyFile(outputPath,filepath.Join(pwd,"tmp","fileZip",info.goos+"_"+info.goarch,filePath2))
+		mustCopyFile(outputPath, filepath.Join(pwd, "tmp", "fileZip", info.goos+"_"+info.goarch, filePath2))
 	}
-	mustZipDir(filepath.Join(pwd,"tmp","fileZip"),filepath.Join(pwd,"tmp","file","yaml2json_all.zip"))
+	mustZipDir(filepath.Join(pwd, "tmp", "fileZip"), filepath.Join(pwd, "tmp", "file", "yaml2json_all.zip"))
 }
 
-type buildInfo struct{
-	goos string
+type buildInfo struct {
+	goos   string
 	goarch string
 }
+
 // copy from /usr/local/go/src/internal/platform/zosarch.go:10
 var buildInfoList = []buildInfo{
 	{"aix", "ppc64"},
@@ -94,4 +95,3 @@ var buildInfoList = []buildInfo{
 	{"windows", "arm"},
 	{"windows", "arm64"},
 }
-

--- a/y2jBuilder/zlib.go
+++ b/y2jBuilder/zlib.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,7 +11,7 @@ import (
 )
 
 func mustCopyFile(fromPath string, toPath string) {
-	content, err := ioutil.ReadFile(fromPath)
+	content, err := os.ReadFile(fromPath)
 	if err != nil {
 		panic(err)
 	}
@@ -20,7 +19,7 @@ func mustCopyFile(fromPath string, toPath string) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(toPath, content, 0777)
+	err = os.WriteFile(toPath, content, 0777)
 	if err != nil {
 		panic(err)
 	}
@@ -58,7 +57,7 @@ func mustZipDir(dir string, targetPath string) {
 		if err != nil {
 			panic(err)
 		}
-		content, err := ioutil.ReadFile(path)
+		content, err := os.ReadFile(path)
 		if err != nil {
 			panic(err)
 		}
@@ -75,7 +74,7 @@ func mustZipDir(dir string, targetPath string) {
 	if err != nil {
 		panic(err)
 	}
-	err = ioutil.WriteFile(targetPath, buf.Bytes(), 0777)
+	err = os.WriteFile(targetPath, buf.Bytes(), 0777)
 	if err != nil {
 		panic(err)
 	}

--- a/y2jBuilder/zlib.go
+++ b/y2jBuilder/zlib.go
@@ -1,97 +1,97 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"bytes"
-	"archive/zip"
-	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
-func mustCopyFile(fromPath string,toPath string){
-	content,err:=ioutil.ReadFile(fromPath)
-	if err!=nil{
+func mustCopyFile(fromPath string, toPath string) {
+	content, err := ioutil.ReadFile(fromPath)
+	if err != nil {
 		panic(err)
 	}
-	err=os.MkdirAll(filepath.Dir(toPath),0777)
-	if err!=nil{
+	err = os.MkdirAll(filepath.Dir(toPath), 0777)
+	if err != nil {
 		panic(err)
 	}
-	err=ioutil.WriteFile(toPath,content,0777)
-	if err!=nil{
+	err = ioutil.WriteFile(toPath, content, 0777)
+	if err != nil {
 		panic(err)
 	}
 }
 
-func mustDeleteFile(path string){
-	err:=os.RemoveAll(path)
-	if err!=nil{
-		if os.IsNotExist(err){
+func mustDeleteFile(path string) {
+	err := os.RemoveAll(path)
+	if err != nil {
+		if os.IsNotExist(err) {
 			return
 		}
 		panic(err)
 	}
 }
 
-func mustZipDir(dir string,targetPath string){
-	dir,err := filepath.Abs(dir)
-	if err!=nil{
+func mustZipDir(dir string, targetPath string) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
 		panic(err)
 	}
-	buf:=&bytes.Buffer{}
-	zipObj:=zip.NewWriter(buf)
-	err=filepath.Walk(dir,func(path string, info os.FileInfo, err error) error{
-		if err!=nil{
+	buf := &bytes.Buffer{}
+	zipObj := zip.NewWriter(buf)
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
 			panic(err)
 		}
-		if info.IsDir(){
+		if info.IsDir() {
 			return nil
 		}
-		relPath,err:=filepath.Rel(dir,path)
-		if err!=nil{
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
 			panic(err)
 		}
-		w,err:=zipObj.Create(relPath)
-		if err!=nil{
+		w, err := zipObj.Create(relPath)
+		if err != nil {
 			panic(err)
 		}
-		content,err:=ioutil.ReadFile(path)
-		if err!=nil{
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
 			panic(err)
 		}
-		_,err=w.Write(content)
-		if err!=nil{
+		_, err = w.Write(content)
+		if err != nil {
 			panic(err)
 		}
 		return nil
 	})
-	if err!=nil{
+	if err != nil {
 		panic(err)
 	}
 	err = zipObj.Close()
-	if err!=nil{
+	if err != nil {
 		panic(err)
 	}
-	err=ioutil.WriteFile(targetPath,buf.Bytes(),0777)
-	if err!=nil{
+	err = ioutil.WriteFile(targetPath, buf.Bytes(), 0777)
+	if err != nil {
 		panic(err)
 	}
 }
 
-func mustRunCmd(cmdList []string,env map[string]string) {
-	fmt.Println(">",strings.Join(cmdList," "))
-	cmd:=exec.Command(cmdList[0],cmdList[1:]...)
+func mustRunCmd(cmdList []string, env map[string]string) {
+	fmt.Println(">", strings.Join(cmdList, " "))
+	cmd := exec.Command(cmdList[0], cmdList[1:]...)
 	cmd.Env = os.Environ()
-	for k,v:=range env{
-		cmd.Env = append(cmd.Env,k+"="+v)
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 	cmd.Stderr = os.Stdout
 	cmd.Stdout = os.Stdout
-	err:=cmd.Run()
-	if err!=nil{
+	err := cmd.Run()
+	if err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Cleanup in `y2jBuilder`:
- gofmt (like #29)
- drop use of deprecated package [io/ioutil](https://pkg.go.dev/io/ioutil)
- add `y2jBuilder` binary to `.gitignore`